### PR TITLE
Configure read timeout correctly for Armeria backend

### DIFF
--- a/armeria-backend/fs2/src/test/scala/sttp/client3/armeria/fs2/ArmeriaFs2StreamingTest.scala
+++ b/armeria-backend/fs2/src/test/scala/sttp/client3/armeria/fs2/ArmeriaFs2StreamingTest.scala
@@ -5,9 +5,9 @@ import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.SttpBackend
 import sttp.client3.impl.fs2.Fs2StreamingTest
 
-class ArmeriaFs2StreamingTest /*extends Fs2StreamingTest {
+class ArmeriaFs2StreamingTest extends Fs2StreamingTest {
   override val backend: SttpBackend[IO, Fs2Streams[IO]] =
     ArmeriaFs2Backend()
 
   override protected def supportsStreamingMultipartParts: Boolean = false
-}*/
+}


### PR DESCRIPTION
Motivation:

Armeria backend did not configure read timeout if default value is used.

Modifications:

- Correctly configure read timeout which is response timeout for Armeria

Result:

- No longer see unexpected read timeout


Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
